### PR TITLE
비서 에이전트 하드코딩 문제 해결 및 채팅 삭제 UX 개선

### DIFF
--- a/admin-dashboard/src/components/AIChat.tsx
+++ b/admin-dashboard/src/components/AIChat.tsx
@@ -135,7 +135,8 @@ const AIChat: React.FC = () => {
       {/* 삭제 확인 모달 */}
       <DeleteConfirmModal
         modal={chatState.deleteConfirmModal}
-        onClose={() => chatState.setDeleteConfirmModal({ isOpen: false, chatTitle: '', chatId: null })}
+        onClose={() => !chatState.isDeletingAll && chatState.setDeleteConfirmModal({ isOpen: false, chatTitle: '', chatId: null })}
+        isDeleting={chatState.isDeletingAll}
         onConfirm={async () => {
           const modalChatId = chatState.deleteConfirmModal.chatId;
           
@@ -148,8 +149,10 @@ const AIChat: React.FC = () => {
             chatHandlers.handleDeleteConfirmModal();
           }
           
-          // 모달 닫기
-          chatState.setDeleteConfirmModal({ isOpen: false, chatTitle: '', chatId: null });
+          // 모달 닫기 (로딩 중이 아닐 때만)
+          if (!chatState.isDeletingAll) {
+            chatState.setDeleteConfirmModal({ isOpen: false, chatTitle: '', chatId: null });
+          }
         }}
       />
     </div>

--- a/admin-dashboard/src/components/chat/DeleteConfirmModal.tsx
+++ b/admin-dashboard/src/components/chat/DeleteConfirmModal.tsx
@@ -5,12 +5,14 @@ interface DeleteConfirmModalProps {
   modal: DeleteConfirmModalType;
   onClose: () => void;
   onConfirm: () => void;
+  isDeleting?: boolean;
 }
 
 const DeleteConfirmModal: React.FC<DeleteConfirmModalProps> = ({
   modal,
   onClose,
-  onConfirm
+  onConfirm,
+  isDeleting = false
 }) => {
   if (!modal.isOpen) return null;
 
@@ -24,21 +26,40 @@ const DeleteConfirmModal: React.FC<DeleteConfirmModalProps> = ({
           "{modal.chatTitle}" 채팅이 영구적으로 삭제됩니다.
         </p>
         <p className="text-sm text-gray-500 mb-6">
-          이 작업은 되돌릴 수 없습니다. 정말로 삭제하시겠습니까?
+          {isDeleting ? '삭제 중입니다... 잠시만 기다려주세요.' : '이 작업은 되돌릴 수 없습니다. 정말로 삭제하시겠습니까?'}
         </p>
+        
+        {isDeleting && (
+          <div className="flex justify-center mb-4">
+            <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-red-600"></div>
+          </div>
+        )}
         
         <div className="flex justify-end space-x-3">
           <button
             onClick={onClose}
-            className="px-4 py-2 text-gray-700 bg-gray-100 hover:bg-gray-200 rounded-md transition-colors"
+            disabled={isDeleting}
+            className={`px-4 py-2 rounded-md transition-colors ${
+              isDeleting 
+                ? 'text-gray-400 bg-gray-100 cursor-not-allowed' 
+                : 'text-gray-700 bg-gray-100 hover:bg-gray-200'
+            }`}
           >
             취소
           </button>
           <button
             onClick={onConfirm}
-            className="px-4 py-2 text-white bg-red-600 hover:bg-red-700 rounded-md transition-colors"
+            disabled={isDeleting}
+            className={`px-4 py-2 text-white rounded-md transition-colors flex items-center space-x-2 ${
+              isDeleting 
+                ? 'bg-red-400 cursor-not-allowed' 
+                : 'bg-red-600 hover:bg-red-700'
+            }`}
           >
-            삭제
+            {isDeleting && (
+              <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-white"></div>
+            )}
+            <span>{isDeleting ? '삭제 중...' : '삭제'}</span>
           </button>
         </div>
       </div>

--- a/admin-dashboard/src/hooks/useChat.ts
+++ b/admin-dashboard/src/hooks/useChat.ts
@@ -77,6 +77,7 @@ export const useChat = () => {
   const [selectedAgentForChat, setSelectedAgentForChat] = useState<Agent | null>(initialChatState.selectedAgentForChat);
   const [showHistory, setShowHistory] = useState(true);
   const [activeTab, setActiveTab] = useState<'history' | 'agents'>('history');
+  const [isDeletingAll, setIsDeletingAll] = useState(false);
   const [loadingChats, setLoadingChats] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [openMenuId, setOpenMenuId] = useState<string | null>(null);
@@ -153,13 +154,23 @@ export const useChat = () => {
 
   // 실제 전체 채팅 삭제 실행
   const executeDeleteAllChats = async () => {
+    setIsDeletingAll(true);
+    
     try {
       // 일반 채팅만 삭제 (북마크된 채팅은 제외)
       const nonBookmarkedChats = chatHistory.filter(chat => !chat.isBookmarked);
+      
+      console.log(`🗑️ ${nonBookmarkedChats.length}개의 채팅 삭제 시작...`);
+      
       // 각 채팅 삭제 API 호출
-      for (const chat of nonBookmarkedChats) {
+      for (let i = 0; i < nonBookmarkedChats.length; i++) {
+        const chat = nonBookmarkedChats[i];
         try {
+          console.log(`🗑️ 삭제 중... (${i + 1}/${nonBookmarkedChats.length}): ${chat.title}`);
           await chatService.deleteChat(chat.id);
+          
+          // 약간의 지연을 추가하여 시각적 피드백 제공
+          await new Promise(resolve => setTimeout(resolve, 100));
         } catch (apiError) {
           console.warn('API 삭제 실패 (계속 진행):', chat.id, apiError);
         }
@@ -178,8 +189,16 @@ export const useChat = () => {
         setCurrentChatId(null);
         setMessages([]);
       }
+      
+      console.log('✅ 전체 채팅 삭제 완료');
+      
+      // 모달 자동 닫기
+      setDeleteConfirmModal({ isOpen: false, chatTitle: '', chatId: null });
+      
     } catch (error) {
       console.error('❌ 전체 채팅 삭제 실패:', error);
+    } finally {
+      setIsDeletingAll(false);
     }
   };
 
@@ -536,6 +555,7 @@ export const useChat = () => {
     setDeleteConfirmModal,
     messageCache,
     setMessageCache,
+    isDeletingAll,
     isDataLoaded,
     isLoadingData,
     

--- a/admin-dashboard/src/hooks/useChatHandlers.ts
+++ b/admin-dashboard/src/hooks/useChatHandlers.ts
@@ -181,129 +181,78 @@ export function useChatHandlers(props: UseChatHandlersProps) {
       
       let aiResponse: ChatMessage;
       
-      // 비서 에이전트 및 교인정보 에이전트는 교회 데이터 우선 조회
+      // 비서 에이전트 및 교인정보 에이전트는 백엔드에서 직접 DB 조회
       if (selectedAgentForChat?.category === 'secretary' || 
           selectedAgentForChat?.name === '교인정보 에이전트' || 
           selectedAgentForChat?.name?.includes('교인정보') ||
           selectedAgentForChat?.name?.includes('비서')) {
         
-        const dbResult = await queryDatabaseViaMCP(userMessage.content);
+        console.log('🔍 비서 에이전트 감지됨:', {
+          agentName: selectedAgentForChat?.name,
+          agentCategory: selectedAgentForChat?.category,
+          message: userMessage.content
+        });
         
-        if (dbResult.success && dbResult.data.length > 0) {
-          // 교회 DB에서 데이터를 찾은 경우, 백엔드에 컨텍스트와 함께 전달
-          const agentId = selectedAgentForChat?.id || agents?.[0]?.id;
+        console.log('📊 백엔드에서 실시간 DB 조회 모드 - 프론트엔드 하드코딩 방지');
+        
+        const agentId = selectedAgentForChat?.id || agents?.[0]?.id;
+        
+        const messageData = {
+          chat_history_id: parseInt(effectiveChatId.replace('chat_', '')) || null,
+          content: userMessage.content.slice(0, 2000),
+          role: 'user' as const,
+          agent_id: agentId,
+          messages: updatedMessages.slice(-4).slice(0, -1).map(msg => ({
+            role: msg.role,
+            content: msg.content.slice(0, 800)
+          })),
+          optimize_speed: true,
+          create_history_if_needed: true,
+          agent_name: selectedAgentForChat?.name || '비서 AI',
+          // 🎯 백엔드에서 실시간 DB 조회하도록 설정 (하드코딩 방지)
+          church_data_context: undefined, // undefined로 설정하여 백엔드에서 직접 조회
+          secretary_mode: true,
+          prioritize_church_data: true,
+          fallback_to_general: true
+        };
+        
+        console.log('🚀 비서 에이전트 API 요청 데이터:', messageData);
+        
+        try {
+          const responseData = await chatService.sendMessage(messageData);
           
-          try {
-            const responseData = await chatService.sendMessage({
-              chat_history_id: parseInt(effectiveChatId.replace('chat_', '')) || null,
-              content: userMessage.content.slice(0, 2000),
-              role: 'user',
-              agent_id: agentId,
-              messages: updatedMessages.slice(-4).slice(0, -1).map(msg => ({
-                role: msg.role,
-                content: msg.content.slice(0, 800)
-              })),
-              optimize_speed: true,
-              create_history_if_needed: true,
-              agent_name: selectedAgentForChat?.name || '비서 AI',
-              // 🎯 교회 데이터 컨텍스트 제공 (우선 처리)
-              church_data_context: JSON.stringify(dbResult.data),
-              secretary_mode: true,
-              prioritize_church_data: true // 교회 데이터 우선 처리 (완전 제한 아님)
-            });
+          let aiContent = '교회 데이터를 기반으로 답변드리겠습니다.';
+          if (responseData.success && responseData.data) {
+            const data = responseData.data;
+            let rawContent = data.ai_response || data.content || data.message;
             
-            // 백엔드 응답 처리
-            let aiContent = '교회 데이터를 기반으로 답변드리겠습니다.';
-            if (responseData.success && responseData.data) {
-              const data = responseData.data;
-              let rawContent = data.ai_response || data.content || data.message;
-              
-              if (typeof rawContent === 'object' && rawContent !== null) {
-                aiContent = rawContent.content || rawContent.message || rawContent.text || JSON.stringify(rawContent, null, 2);
-              } else if (typeof rawContent === 'string') {
-                aiContent = rawContent;
-              }
+            if (typeof rawContent === 'object' && rawContent !== null) {
+              aiContent = rawContent.content || rawContent.message || rawContent.text || JSON.stringify(rawContent, null, 2);
+            } else if (typeof rawContent === 'string') {
+              aiContent = rawContent;
             }
-            
-            aiResponse = {
-              id: `ai_${Date.now()}`,
-              role: 'assistant',
-              content: aiContent,
-              timestamp: new Date(),
-              is_secretary_agent: true,
-              data_sources: ['교회 데이터베이스'],
-              query_type: 'church_data_query'
-            };
-          } catch (backendError) {
-            console.warn('백엔드 처리 실패, 직접 데이터 표시:', backendError);
-            // 백엔드 실패 시 직접 포맷팅해서 표시
-            aiResponse = {
-              id: `ai_${Date.now()}`,
-              role: 'assistant',
-              content: `교회 데이터를 조회한 결과입니다:\n\n${formatChurchData(dbResult.data)}`,
-              timestamp: new Date(),
-              is_secretary_agent: true,
-              data_sources: ['교회 데이터베이스'],
-              query_type: 'church_data_query'
-            };
           }
-        } else {
-          // DB 조회 실패 시에도 백엔드에 교회 컨텍스트 모드로 요청
-          const agentId = selectedAgentForChat?.id || agents?.[0]?.id;
           
-          try {
-            const responseData = await chatService.sendMessage({
-              chat_history_id: parseInt(effectiveChatId.replace('chat_', '')) || null,
-              content: userMessage.content.slice(0, 2000),
-              role: 'user',
-              agent_id: agentId,
-              messages: updatedMessages.slice(-4).slice(0, -1).map(msg => ({
-                role: msg.role,
-                content: msg.content.slice(0, 800)
-              })),
-              optimize_speed: true,
-              create_history_if_needed: true,
-              agent_name: selectedAgentForChat?.name || '비서 AI',
-              // 🎯 교회 컨텍스트 우선 모드
-              secretary_mode: true,
-              prioritize_church_data: true, // 교회 데이터 우선하지만 일반 지식도 허용
-              fallback_to_general: true // 교회 데이터 부족 시 일반 GPT 응답 허용
-            });
-            
-            let aiContent = '교회 데이터베이스에서 관련 정보를 찾지 못했지만, 일반적인 답변을 드리겠습니다.';
-            
-            if (responseData.success && responseData.data) {
-              const data = responseData.data;
-              let rawContent = data.ai_response || data.content || data.message;
-              
-              if (typeof rawContent === 'object' && rawContent !== null) {
-                aiContent = rawContent.content || rawContent.message || rawContent.text || aiContent;
-              } else if (typeof rawContent === 'string') {
-                aiContent = rawContent;
-              }
-            }
-            
-            aiResponse = {
-              id: `ai_${Date.now()}`,
-              role: 'assistant',
-              content: aiContent,
-              timestamp: new Date(),
-              is_secretary_agent: true,
-              data_sources: ['교회 데이터베이스', 'AI 일반 지식'],
-              query_type: 'hybrid_response'
-            };
-          } catch (backendError) {
-            console.warn('백엔드 교회 컨텍스트 모드 실패:', backendError);
-            aiResponse = {
-              id: `ai_${Date.now()}`,
-              role: 'assistant',
-              content: `교회 데이터베이스에서 관련 정보를 찾지 못했지만, 일반적인 답변을 드리겠습니다.\n\n${dbResult.error ? `**참고:** ${dbResult.error}` : ''}\n\n더 정확한 정보를 위해 다음을 시도해보세요:\n- 구체적인 성도명이나 날짜 제공\n- 교회 관련 용어 사용`,
-              timestamp: new Date(),
-              is_secretary_agent: true,
-              data_sources: ['교회 데이터베이스'],
-              query_type: 'church_data_not_found'
-            };
-          }
+          aiResponse = {
+            id: `ai_${Date.now()}`,
+            role: 'assistant',
+            content: aiContent,
+            timestamp: new Date(),
+            is_secretary_agent: true,
+            data_sources: ['교회 데이터베이스'],
+            query_type: 'church_data_query'
+          };
+        } catch (backendError) {
+          console.warn('백엔드 비서 에이전트 호출 실패:', backendError);
+          aiResponse = {
+            id: `ai_${Date.now()}`,
+            role: 'assistant',
+            content: '죄송합니다. 현재 교회 데이터를 조회할 수 없습니다. 잠시 후 다시 시도해 주세요.',
+            timestamp: new Date(),
+            is_secretary_agent: true,
+            data_sources: ['교회 데이터베이스'],
+            query_type: 'church_data_error'
+          };
         }
       } else {
         // 에이전트 ID 검증

--- a/admin-dashboard/src/utils/mcpUtils.ts
+++ b/admin-dashboard/src/utils/mcpUtils.ts
@@ -267,12 +267,12 @@ export const queryDatabaseViaMCP = async (
     
     // 간단한 로컬 처리 (Edge Functions 대신)
     try {
-      // 교인 수 질문인 경우 간단한 답변 반환
+      // 교인 수 질문은 백엔드에서 실시간 DB 조회로 처리
       if (userQuestion.includes('교인') && (userQuestion.includes('몇') || userQuestion.includes('수'))) {
         return {
-          success: true,
-          data: [{ message: '현재 등록된 교인 수는 100명입니다.' }],
-          error: undefined
+          success: false,
+          data: [],
+          error: '교인 수는 백엔드에서 실시간 조회합니다.'
         };
       }
       


### PR DESCRIPTION
- 비서 에이전트의 교인 수 하드코딩(100명) 문제 해결
- 백엔드 실시간 DB 조회를 위해 church_data_context를 undefined로 설정
- 채팅 전체 삭제 시 로딩 인디케이터 및 진행률 표시 추가
- mcpUtils.ts의 하드코딩된 교인 수 응답 제거

🤖 Generated with [Claude Code](https://claude.ai/code)