### PR TITLE
교인 정보 등록 모달 확장 - 25개 신규 필드 추가

### DIFF
--- a/admin-dashboard/docs/enhanced-member-fields.md
+++ b/admin-dashboard/docs/enhanced-member-fields.md
@@ -1,0 +1,294 @@
+# Enhanced Member Fields Documentation
+
+## 📋 개요
+Smart Yoram 교인 관리 시스템에 25개의 새로운 필드가 추가되어 보다 상세하고 체계적인 교인 정보 관리가 가능해졌습니다.
+
+## 🆕 새로 추가된 필드들
+
+### 1. 교회 관련 정보 (Enhanced Church Information)
+
+| 필드명 | 타입 | 설명 | 예시값 |
+|--------|------|------|--------|
+| `member_type` | String | 교인구분 | "정교인", "학습교인", "세례교인" |
+| `confirmation_date` | Date | 입교일 | "2023-12-25" |
+| `sub_district` | String | 부구역 | "A구역", "청년부구역" |
+| `age_group` | String | 나이그룹 | "성인", "청년", "학생", "어린이" |
+
+### 2. 지역 정보 (Regional Information)
+
+| 필드명 | 타입 | 설명 | 예시값 |
+|--------|------|------|--------|
+| `region_1` | String | 안도구 1 | "서울시" |
+| `region_2` | String | 안도구 2 | "강남구" |
+| `region_3` | String | 안도구 3 | "역삼동" |
+| `postal_code` | String | 우편번호 | "06234" |
+
+### 3. 인도자 정보 (Inviter Information)
+
+| 필드명 | 타입 | 설명 | 예시값 |
+|--------|------|------|--------|
+| `inviter3_member_id` | Integer | 세 번째 인도자 ID | 123 |
+
+**참고**: `inviter1_member_id`, `inviter2_member_id`는 기존에 존재했음
+
+### 4. 연락 정보 (Contact Details)
+
+| 필드명 | 타입 | 설명 | 예시값 |
+|--------|------|------|--------|
+| `last_contact_date` | Date | 마지막 연락일 | "2024-01-15" |
+
+### 5. 신앙 정보 (Spiritual Information)
+
+| 필드명 | 타입 | 설명 | 예시값 |
+|--------|------|------|--------|
+| `spiritual_grade` | String | 신급 | "A급", "B급", "초신자" |
+
+### 6. 직업 정보 (Enhanced Job Information)
+
+| 필드명 | 타입 | 설명 | 예시값 |
+|--------|------|------|--------|
+| `job_category` | String | 직업분류 | "사무직", "교육직", "의료진" |
+| `job_detail` | String | 구체적 업무 | "소프트웨어 개발", "초등학교 교사" |
+| `job_position` | String | 직책/직위 | "팀장", "과장", "원장" |
+
+### 7. 사역 정보 (Ministry Information)
+
+| 필드명 | 타입 | 설명 | 예시값 |
+|--------|------|------|--------|
+| `ministry_start_date` | Date | 사역 시작일 | "2023-01-01" |
+| `neighboring_church` | String | 이웃교회 | "은혜교회", "사랑교회" |
+| `position_decision` | String | 직분 결정 | "장로 추천", "권사 임명" |
+| `daily_activity` | Text | 일상 활동 | "새벽기도 참석, 구역모임 리더" |
+
+### 8. 자유 필드 (Custom Fields)
+
+| 필드명 | 타입 | 설명 | 사용 예시 |
+|--------|------|------|----------|
+| `custom_field_1` | String | 자유필드 1 | "취미: 등산" |
+| `custom_field_2` | String | 자유필드 2 | "특기: 피아노" |
+| `custom_field_3` | String | 자유필드 3 | "관심분야: 선교" |
+| ... | ... | ... | ... |
+| `custom_field_12` | String | 자유필드 12 | "기타 정보" |
+
+### 9. 특별 정보 (Special Information)
+
+| 필드명 | 타입 | 설명 | 예시값 |
+|--------|------|------|--------|
+| `special_notes` | Text | 개인 특별사항 | "건강상 주의사항, 가족관계 특이사항 등" |
+
+## 🔗 API 사용법
+
+### GET /api/v1/members/
+**응답 예시:**
+```json
+{
+  "id": 1,
+  "name": "홍길동",
+  "email": "hong@example.com",
+  "phone": "010-1234-5678",
+  
+  // 새로 추가된 필드들
+  "member_type": "정교인",
+  "confirmation_date": "2023-12-25",
+  "sub_district": "A구역",
+  "age_group": "성인",
+  
+  "region_1": "서울시",
+  "region_2": "강남구", 
+  "region_3": "역삼동",
+  "postal_code": "06234",
+  
+  "inviter3_member_id": 123,
+  "last_contact_date": "2024-01-15",
+  "spiritual_grade": "A급",
+  
+  "job_category": "사무직",
+  "job_detail": "소프트웨어 개발",
+  "job_position": "팀장",
+  
+  "ministry_start_date": "2023-01-01",
+  "neighboring_church": "은혜교회",
+  "position_decision": "장로 추천",
+  "daily_activity": "새벽기도 참석, 구역모임 리더",
+  
+  "custom_field_1": "취미: 등산",
+  "custom_field_2": "특기: 피아노",
+  // ... custom_field_12까지
+  
+  "special_notes": "건강상 주의사항 있음"
+}
+```
+
+### POST /api/v1/members/ (교인 추가)
+**요청 예시:**
+```json
+{
+  "name": "김철수",
+  "email": "kim@example.com", 
+  "phone": "010-9876-5432",
+  "address": "서울시 강남구 역삼동 123-45",
+  
+  // 새 필드들 (모두 optional)
+  "member_type": "정교인",
+  "confirmation_date": "2024-01-01",
+  "sub_district": "B구역",
+  "age_group": "청년",
+  
+  "region_1": "서울시",
+  "region_2": "강남구",
+  "region_3": "역삼동", 
+  "postal_code": "06234",
+  
+  "spiritual_grade": "초신자",
+  "job_category": "교육직",
+  "job_detail": "고등학교 교사",
+  "job_position": "부장교사",
+  
+  "custom_field_1": "바이올린 연주 가능",
+  "custom_field_2": "청년부 찬양팀",
+  
+  "special_notes": "매주 수요일 저녁 시간 참석 어려움"
+}
+```
+
+## 📝 프론트엔드 구현 가이드
+
+### 1. 교인 등록 폼 확장
+```javascript
+const memberFormFields = {
+  // 기존 필드들
+  name: '',
+  email: '',
+  phone: '',
+  address: '',
+  
+  // 새 필드들
+  member_type: '',
+  confirmation_date: '',
+  sub_district: '',
+  age_group: '',
+  
+  region_1: '',
+  region_2: '', 
+  region_3: '',
+  postal_code: '',
+  
+  spiritual_grade: '',
+  job_category: '',
+  job_detail: '',
+  job_position: '',
+  
+  ministry_start_date: '',
+  neighboring_church: '',
+  position_decision: '',
+  daily_activity: '',
+  
+  custom_field_1: '',
+  custom_field_2: '',
+  // ... custom_field_12까지
+  
+  special_notes: ''
+};
+```
+
+### 2. 드롭다운 옵션 예시
+```javascript
+const memberTypeOptions = [
+  { value: '정교인', label: '정교인' },
+  { value: '학습교인', label: '학습교인' },
+  { value: '세례교인', label: '세례교인' },
+  { value: '방문자', label: '방문자' }
+];
+
+const ageGroupOptions = [
+  { value: '어린이', label: '어린이 (0-12세)' },
+  { value: '학생', label: '학생 (13-19세)' },
+  { value: '청년', label: '청년 (20-35세)' },
+  { value: '성인', label: '성인 (36-65세)' },
+  { value: '시니어', label: '시니어 (65세+)' }
+];
+
+const spiritualGradeOptions = [
+  { value: '초신자', label: '초신자' },
+  { value: 'B급', label: 'B급' },
+  { value: 'A급', label: 'A급' },
+  { value: '리더', label: '리더' }
+];
+
+const jobCategoryOptions = [
+  { value: '사무직', label: '사무직' },
+  { value: '교육직', label: '교육직' },
+  { value: '의료진', label: '의료진' },
+  { value: '서비스업', label: '서비스업' },
+  { value: '자영업', label: '자영업' },
+  { value: '학생', label: '학생' },
+  { value: '주부', label: '주부' },
+  { value: '기타', label: '기타' }
+];
+```
+
+### 3. 폼 섹션 구성 제안
+```javascript
+const formSections = [
+  {
+    title: "기본 정보",
+    fields: ["name", "email", "phone", "address"]
+  },
+  {
+    title: "교회 정보", 
+    fields: ["member_type", "confirmation_date", "sub_district", "age_group"]
+  },
+  {
+    title: "지역 정보",
+    fields: ["region_1", "region_2", "region_3", "postal_code"]
+  },
+  {
+    title: "신앙 정보",
+    fields: ["spiritual_grade", "ministry_start_date", "daily_activity"]
+  },
+  {
+    title: "직업 정보", 
+    fields: ["job_category", "job_detail", "job_position"]
+  },
+  {
+    title: "추가 정보",
+    fields: ["neighboring_church", "position_decision"]
+  },
+  {
+    title: "자유 필드",
+    fields: ["custom_field_1", "custom_field_2", "custom_field_3", "custom_field_4"]
+  },
+  {
+    title: "특별 사항",
+    fields: ["special_notes"]
+  }
+];
+```
+
+## ⚠️ 주의사항
+
+### 1. 모든 새 필드는 Optional
+- 기존 시스템과의 호환성을 위해 모든 새 필드는 `null` 허용
+- 필수값 검증 없이 부분적으로 입력 가능
+
+### 2. 데이터 타입 주의
+- Date 필드: `YYYY-MM-DD` 형식 사용
+- Text vs String: `daily_activity`, `special_notes`는 긴 텍스트 입력 가능
+
+### 3. 외래키 관계
+- `inviter3_member_id`는 같은 교회의 다른 교인 ID 참조
+- 존재하지 않는 ID 입력 시 에러 발생
+
+### 4. 성능 고려사항
+- 검색 성능을 위해 자주 사용되는 필드에는 인덱스 추가됨
+- `member_type`, `age_group`, `spiritual_grade`, `job_category` 등
+
+## 🚀 다음 단계
+1. 프론트엔드에서 새 필드들을 단계적으로 추가
+2. 사용자 테스트를 통한 UI/UX 개선
+3. 드롭다운 옵션들을 관리자가 설정할 수 있도록 확장
+4. 필드별 권한 설정 기능 추가
+
+---
+
+**📞 문의사항**: 구현 중 문제가 있거나 추가 설명이 필요한 경우 백엔드 팀에 문의해 주세요.

--- a/admin-dashboard/src/components/AddMemberModal.tsx
+++ b/admin-dashboard/src/components/AddMemberModal.tsx
@@ -36,9 +36,30 @@ const AddMemberModal: React.FC<AddMemberModalProps> = ({
     name: '', name_eng: '', email: '', gender: '남', birthdate: '', phone: '',
     // 사역 정보  
     position: '', district: '', department_code: '', position_code: '', appointed_on: '',
-    ordination_church: '', job_title: '', workplace: '', workplace_phone: '',
+    ordination_church: '', workplace: '', workplace_phone: '',
     // 개인 정보
-    address: '', marital_status: '', spouse_name: '', married_on: ''
+    address: '', marital_status: '', spouse_name: '', married_on: '',
+    // 새로 추가된 필드들
+    // 교회 정보
+    member_type: '', confirmation_date: '', sub_district: '', age_group: '',
+    // 지역 정보
+    region_1: '', region_2: '', region_3: '', postal_code: '',
+    // 인도자 정보
+    inviter3_member_id: '',
+    // 연락 정보
+    last_contact_date: '',
+    // 신앙 정보
+    spiritual_grade: '',
+    // 직업 정보 확장
+    job_category: '', job_detail: '', job_position: '',
+    // 사역 정보 확장
+    ministry_start_date: '', neighboring_church: '', position_decision: '', daily_activity: '',
+    // 자유 필드
+    custom_field_1: '', custom_field_2: '', custom_field_3: '', custom_field_4: '',
+    custom_field_5: '', custom_field_6: '', custom_field_7: '', custom_field_8: '',
+    custom_field_9: '', custom_field_10: '', custom_field_11: '', custom_field_12: '',
+    // 특별 사항
+    special_notes: ''
   });
 
   // 코드 데이터
@@ -65,6 +86,40 @@ const AddMemberModal: React.FC<AddMemberModalProps> = ({
     { value: '사별', label: '사별' }
   ];
 
+  // 새로 추가된 드롭다운 옵션들
+  const memberTypeOptions = [
+    { value: '정교인', label: '정교인' },
+    { value: '학습교인', label: '학습교인' },
+    { value: '세례교인', label: '세례교인' },
+    { value: '방문자', label: '방문자' }
+  ];
+
+  const ageGroupOptions = [
+    { value: '어린이', label: '어린이 (0-12세)' },
+    { value: '학생', label: '학생 (13-19세)' },
+    { value: '청년', label: '청년 (20-35세)' },
+    { value: '성인', label: '성인 (36-65세)' },
+    { value: '시니어', label: '시니어 (65세+)' }
+  ];
+
+  const spiritualGradeOptions = [
+    { value: '초신자', label: '초신자' },
+    { value: 'B급', label: 'B급' },
+    { value: 'A급', label: 'A급' },
+    { value: '리더', label: '리더' }
+  ];
+
+  const jobCategoryOptions = [
+    { value: '사무직', label: '사무직' },
+    { value: '교육직', label: '교육직' },
+    { value: '의료진', label: '의료진' },
+    { value: '서비스업', label: '서비스업' },
+    { value: '자영업', label: '자영업' },
+    { value: '학생', label: '학생' },
+    { value: '주부', label: '주부' },
+    { value: '기타', label: '기타' }
+  ];
+
   const isFormValid = () => {
     return formData.name && formData.email && formData.phone;
   };
@@ -74,8 +129,18 @@ const AddMemberModal: React.FC<AddMemberModalProps> = ({
     setFormData({
       name: '', name_eng: '', email: '', gender: '남', birthdate: '', phone: '',
       position: '', district: '', department_code: '', position_code: '', appointed_on: '',
-      ordination_church: '', job_title: '', workplace: '', workplace_phone: '',
-      address: '', marital_status: '', spouse_name: '', married_on: ''
+      ordination_church: '', workplace: '', workplace_phone: '',
+      address: '', marital_status: '', spouse_name: '', married_on: '',
+      // 새로 추가된 필드들 리셋
+      member_type: '', confirmation_date: '', sub_district: '', age_group: '',
+      region_1: '', region_2: '', region_3: '', postal_code: '',
+      inviter3_member_id: '', last_contact_date: '', spiritual_grade: '',
+      job_category: '', job_detail: '', job_position: '',
+      ministry_start_date: '', neighboring_church: '', position_decision: '', daily_activity: '',
+      custom_field_1: '', custom_field_2: '', custom_field_3: '', custom_field_4: '',
+      custom_field_5: '', custom_field_6: '', custom_field_7: '', custom_field_8: '',
+      custom_field_9: '', custom_field_10: '', custom_field_11: '', custom_field_12: '',
+      special_notes: ''
     });
     onOpenChange(false);
   };
@@ -89,6 +154,7 @@ const AddMemberModal: React.FC<AddMemberModalProps> = ({
     setLoading(true);
     try {
       const memberData = {
+        // 기존 필드들
         name: formData.name, 
         name_eng: formData.name_eng, 
         email: formData.email,
@@ -102,12 +168,61 @@ const AddMemberModal: React.FC<AddMemberModalProps> = ({
         position_code: formData.position_code,
         appointed_on: formData.appointed_on,
         ordination_church: formData.ordination_church,
-        job_title: formData.job_title,
         workplace: formData.workplace,
         workplace_phone: formData.workplace_phone,
         marital_status: formData.marital_status,
         spouse_name: formData.spouse_name,
-        married_on: formData.married_on
+        married_on: formData.married_on,
+        
+        // 새로 추가된 25개 필드들
+        // 교회 정보 확장
+        member_type: formData.member_type,
+        confirmation_date: formData.confirmation_date,
+        sub_district: formData.sub_district,
+        age_group: formData.age_group,
+        
+        // 지역 정보
+        region_1: formData.region_1,
+        region_2: formData.region_2,
+        region_3: formData.region_3,
+        postal_code: formData.postal_code,
+        
+        // 인도자 정보
+        inviter3_member_id: formData.inviter3_member_id ? parseInt(formData.inviter3_member_id) : null,
+        
+        // 연락 정보
+        last_contact_date: formData.last_contact_date,
+        
+        // 신앙 정보
+        spiritual_grade: formData.spiritual_grade,
+        
+        // 직업 정보 확장
+        job_category: formData.job_category,
+        job_detail: formData.job_detail,
+        job_position: formData.job_position,
+        
+        // 사역 정보 확장
+        ministry_start_date: formData.ministry_start_date,
+        neighboring_church: formData.neighboring_church,
+        position_decision: formData.position_decision,
+        daily_activity: formData.daily_activity,
+        
+        // 자유 필드들 (12개)
+        custom_field_1: formData.custom_field_1,
+        custom_field_2: formData.custom_field_2,
+        custom_field_3: formData.custom_field_3,
+        custom_field_4: formData.custom_field_4,
+        custom_field_5: formData.custom_field_5,
+        custom_field_6: formData.custom_field_6,
+        custom_field_7: formData.custom_field_7,
+        custom_field_8: formData.custom_field_8,
+        custom_field_9: formData.custom_field_9,
+        custom_field_10: formData.custom_field_10,
+        custom_field_11: formData.custom_field_11,
+        custom_field_12: formData.custom_field_12,
+        
+        // 특별 사항
+        special_notes: formData.special_notes
       };
       
       await api.post('/members/', memberData);
@@ -315,23 +430,13 @@ const AddMemberModal: React.FC<AddMemberModalProps> = ({
             </div>
           </div>
 
-          {/* 사역 및 직업 정보 */}
+          {/* 직장 정보 */}
           <div className="bg-blue-50/50 rounded-lg p-6">
             <h3 className="text-lg font-semibold text-foreground mb-4 flex items-center gap-2">
               <Briefcase className="w-5 h-5" />
-              사역 및 직업 정보
+              직장 정보
             </h3>
-            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-              {/* 직업 */}
-              <div>
-                <label className="block text-sm font-medium text-foreground mb-1">직업</label>
-                <Input
-                  value={formData.job_title}
-                  onChange={(e) => setFormData(prev => ({ ...prev, job_title: e.target.value }))}
-                  placeholder="회사원, 교사 등"
-                />
-              </div>
-
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
               {/* 직장명 */}
               <div>
                 <label className="block text-sm font-medium text-foreground mb-1">직장명</label>
@@ -405,13 +510,295 @@ const AddMemberModal: React.FC<AddMemberModalProps> = ({
               <MapPin className="w-5 h-5" />
               주소 정보
             </h3>
-            <div>
-              <label className="block text-sm font-medium text-foreground mb-1">주소</label>
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+              <div>
+                <label className="block text-sm font-medium text-foreground mb-1">우편번호</label>
+                <Input
+                  value={formData.postal_code}
+                  onChange={(e) => setFormData(prev => ({ ...prev, postal_code: e.target.value }))}
+                  placeholder="06234"
+                />
+              </div>
+              <div className="md:col-span-1">
+                <label className="block text-sm font-medium text-foreground mb-1">주소</label>
+                <Textarea
+                  value={formData.address}
+                  onChange={(e) => setFormData(prev => ({ ...prev, address: e.target.value }))}
+                  placeholder="상세 주소 입력"
+                  rows={3}
+                />
+              </div>
+            </div>
+            
+            {/* 지역 정보 */}
+            <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mt-4">
+              <div>
+                <label className="block text-sm font-medium text-foreground mb-1">지역 1</label>
+                <Input
+                  value={formData.region_1}
+                  onChange={(e) => setFormData(prev => ({ ...prev, region_1: e.target.value }))}
+                  placeholder="서울시"
+                />
+              </div>
+              <div>
+                <label className="block text-sm font-medium text-foreground mb-1">지역 2</label>
+                <Input
+                  value={formData.region_2}
+                  onChange={(e) => setFormData(prev => ({ ...prev, region_2: e.target.value }))}
+                  placeholder="강남구"
+                />
+              </div>
+              <div>
+                <label className="block text-sm font-medium text-foreground mb-1">지역 3</label>
+                <Input
+                  value={formData.region_3}
+                  onChange={(e) => setFormData(prev => ({ ...prev, region_3: e.target.value }))}
+                  placeholder="역삼동"
+                />
+              </div>
+            </div>
+          </div>
+
+          {/* 교회 정보 확장 */}
+          <div className="bg-purple-50/50 rounded-lg p-6">
+            <h3 className="text-lg font-semibold text-foreground mb-4 flex items-center gap-2">
+              <Church className="w-5 h-5" />
+              교회 정보 확장
+            </h3>
+            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+              {/* 교인구분 */}
+              <div>
+                <label className="block text-sm font-medium text-foreground mb-1">교인구분</label>
+                <Select value={formData.member_type} onValueChange={(value) => setFormData(prev => ({ ...prev, member_type: value }))}>
+                  <SelectTrigger>
+                    <SelectValue placeholder="구분 선택" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {memberTypeOptions.map(type => (
+                      <SelectItem key={type.value} value={type.value}>{type.label}</SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+
+              {/* 입교일 */}
+              <div>
+                <label className="block text-sm font-medium text-foreground mb-1">입교일</label>
+                <Input
+                  type="date"
+                  value={formData.confirmation_date}
+                  onChange={(e) => setFormData(prev => ({ ...prev, confirmation_date: e.target.value }))}
+                />
+              </div>
+
+              {/* 부구역 */}
+              <div>
+                <label className="block text-sm font-medium text-foreground mb-1">부구역</label>
+                <Input
+                  value={formData.sub_district}
+                  onChange={(e) => setFormData(prev => ({ ...prev, sub_district: e.target.value }))}
+                  placeholder="A구역, B구역 등"
+                />
+              </div>
+
+              {/* 나이그룹 */}
+              <div>
+                <label className="block text-sm font-medium text-foreground mb-1">나이그룹</label>
+                <Select value={formData.age_group} onValueChange={(value) => setFormData(prev => ({ ...prev, age_group: value }))}>
+                  <SelectTrigger>
+                    <SelectValue placeholder="그룹 선택" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {ageGroupOptions.map(age => (
+                      <SelectItem key={age.value} value={age.value}>{age.label}</SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+
+              {/* 신급 */}
+              <div>
+                <label className="block text-sm font-medium text-foreground mb-1">신급</label>
+                <Select value={formData.spiritual_grade} onValueChange={(value) => setFormData(prev => ({ ...prev, spiritual_grade: value }))}>
+                  <SelectTrigger>
+                    <SelectValue placeholder="신급 선택" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {spiritualGradeOptions.map(grade => (
+                      <SelectItem key={grade.value} value={grade.value}>{grade.label}</SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+
+              {/* 마지막 연락일 */}
+              <div>
+                <label className="block text-sm font-medium text-foreground mb-1">마지막 연락일</label>
+                <Input
+                  type="date"
+                  value={formData.last_contact_date}
+                  onChange={(e) => setFormData(prev => ({ ...prev, last_contact_date: e.target.value }))}
+                />
+              </div>
+            </div>
+          </div>
+
+          {/* 직업 정보 */}
+          <div className="bg-indigo-50/50 rounded-lg p-6">
+            <h3 className="text-lg font-semibold text-foreground mb-4 flex items-center gap-2">
+              <Briefcase className="w-5 h-5" />
+              직업 정보
+            </h3>
+            <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+              {/* 직업분류 */}
+              <div>
+                <label className="block text-sm font-medium text-foreground mb-1">직업분류</label>
+                <Select value={formData.job_category} onValueChange={(value) => setFormData(prev => ({ ...prev, job_category: value }))}>
+                  <SelectTrigger>
+                    <SelectValue placeholder="분류 선택" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {jobCategoryOptions.map(job => (
+                      <SelectItem key={job.value} value={job.value}>{job.label}</SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+
+              {/* 구체적 업무 */}
+              <div>
+                <label className="block text-sm font-medium text-foreground mb-1">구체적 업무</label>
+                <Input
+                  value={formData.job_detail}
+                  onChange={(e) => setFormData(prev => ({ ...prev, job_detail: e.target.value }))}
+                  placeholder="소프트웨어 개발, 초등학교 교사 등"
+                />
+              </div>
+
+              {/* 직책/직위 */}
+              <div>
+                <label className="block text-sm font-medium text-foreground mb-1">직책/직위</label>
+                <Input
+                  value={formData.job_position}
+                  onChange={(e) => setFormData(prev => ({ ...prev, job_position: e.target.value }))}
+                  placeholder="팀장, 과장, 원장 등"
+                />
+              </div>
+            </div>
+          </div>
+
+          {/* 사역 정보 확장 */}
+          <div className="bg-teal-50/50 rounded-lg p-6">
+            <h3 className="text-lg font-semibold text-foreground mb-4 flex items-center gap-2">
+              <Church className="w-5 h-5" />
+              사역 정보 확장
+            </h3>
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+              {/* 사역 시작일 */}
+              <div>
+                <label className="block text-sm font-medium text-foreground mb-1">사역 시작일</label>
+                <Input
+                  type="date"
+                  value={formData.ministry_start_date}
+                  onChange={(e) => setFormData(prev => ({ ...prev, ministry_start_date: e.target.value }))}
+                />
+              </div>
+
+              {/* 이웃교회 */}
+              <div>
+                <label className="block text-sm font-medium text-foreground mb-1">이웃교회</label>
+                <Input
+                  value={formData.neighboring_church}
+                  onChange={(e) => setFormData(prev => ({ ...prev, neighboring_church: e.target.value }))}
+                  placeholder="은혜교회, 사랑교회 등"
+                />
+              </div>
+
+              {/* 직분 결정 */}
+              <div>
+                <label className="block text-sm font-medium text-foreground mb-1">직분 결정</label>
+                <Input
+                  value={formData.position_decision}
+                  onChange={(e) => setFormData(prev => ({ ...prev, position_decision: e.target.value }))}
+                  placeholder="장로 추천, 권사 임명 등"
+                />
+              </div>
+
+              {/* 인도자3 */}
+              <div>
+                <label className="block text-sm font-medium text-foreground mb-1">인도자3 ID</label>
+                <Input
+                  type="number"
+                  value={formData.inviter3_member_id}
+                  onChange={(e) => setFormData(prev => ({ ...prev, inviter3_member_id: e.target.value }))}
+                  placeholder="교인 ID 입력"
+                />
+              </div>
+            </div>
+
+            {/* 일상 활동 */}
+            <div className="mt-4">
+              <label className="block text-sm font-medium text-foreground mb-1">일상 활동</label>
               <Textarea
-                value={formData.address}
-                onChange={(e) => setFormData(prev => ({ ...prev, address: e.target.value }))}
-                placeholder="상세 주소 입력"
+                value={formData.daily_activity}
+                onChange={(e) => setFormData(prev => ({ ...prev, daily_activity: e.target.value }))}
+                placeholder="새벽기도 참석, 구역모임 리더 등"
                 rows={3}
+              />
+            </div>
+          </div>
+
+          {/* 자유 필드 */}
+          <div className="bg-pink-50/50 rounded-lg p-6">
+            <h3 className="text-lg font-semibold text-foreground mb-4 flex items-center gap-2">
+              <Plus className="w-5 h-5" />
+              자유 필드 (커스텀 정보)
+            </h3>
+            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+              {/* 자유필드 1-6 */}
+              {[1, 2, 3, 4, 5, 6].map(num => (
+                <div key={num}>
+                  <label className="block text-sm font-medium text-foreground mb-1">자유필드 {num}</label>
+                  <Input
+                    value={(formData as any)[`custom_field_${num}`]}
+                    onChange={(e) => setFormData(prev => ({ ...prev, [`custom_field_${num}`]: e.target.value }))}
+                    placeholder={`추가 정보 ${num}`}
+                  />
+                </div>
+              ))}
+            </div>
+            
+            {/* 자유필드 7-12 (접을 수 있는 영역) */}
+            <details className="mt-4">
+              <summary className="cursor-pointer text-sm font-medium text-foreground mb-2">추가 자유필드 (7-12)</summary>
+              <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+                {[7, 8, 9, 10, 11, 12].map(num => (
+                  <div key={num}>
+                    <label className="block text-sm font-medium text-foreground mb-1">자유필드 {num}</label>
+                    <Input
+                      value={(formData as any)[`custom_field_${num}`]}
+                      onChange={(e) => setFormData(prev => ({ ...prev, [`custom_field_${num}`]: e.target.value }))}
+                      placeholder={`추가 정보 ${num}`}
+                    />
+                  </div>
+                ))}
+              </div>
+            </details>
+          </div>
+
+          {/* 특별 사항 */}
+          <div className="bg-red-50/50 rounded-lg p-6">
+            <h3 className="text-lg font-semibold text-foreground mb-4 flex items-center gap-2">
+              <ContactRound className="w-5 h-5" />
+              특별 사항
+            </h3>
+            <div>
+              <label className="block text-sm font-medium text-foreground mb-1">개인 특별사항</label>
+              <Textarea
+                value={formData.special_notes}
+                onChange={(e) => setFormData(prev => ({ ...prev, special_notes: e.target.value }))}
+                placeholder="건강상 주의사항, 가족관계 특이사항 등"
+                rows={4}
               />
             </div>
           </div>


### PR DESCRIPTION
- enhanced-member-fields.md 문서 기준으로 교인 등록 폼 대폭 확장
- 새로운 필드들:
  * 교회 정보: 교인구분, 입교일, 부구역, 나이그룹, 신급
  * 지역 정보: 지역1-3, 우편번호
  * 직업 정보: 직업분류, 구체적업무, 직책 (기존 job_title 중복 제거)
  * 사역 정보: 사역시작일, 이웃교회, 직분결정, 일상활동
  * 인도자 정보: 인도자3 ID
  * 자유 필드: custom_field_1~12 (7-12번은 접을 수 있음)
  * 특별 사항: 개인 특별사항

- UI 개선:
  * 색상별 섹션 구분으로 가독성 향상
  * 드롭다운 옵션들 추가 (교인구분, 나이그룹, 신급, 직업분류)
  * 중복 필드 제거 및 논리적 섹션 재구성

- API 확장: 모든 새 필드들을 POST /members/ 요청에 포함

🤖 Generated with [Claude Code](https://claude.ai/code)