### PR TITLE
로그인 리다이렉션 문제 수정 - 토큰 키 불일치 해결

### DIFF
--- a/admin-dashboard/src/components/PrivateRoute.tsx
+++ b/admin-dashboard/src/components/PrivateRoute.tsx
@@ -6,7 +6,7 @@ interface PrivateRouteProps {
 }
 
 const PrivateRoute: React.FC<PrivateRouteProps> = ({ children }) => {
-  const token = localStorage.getItem('token');
+  const token = localStorage.getItem('access_token');
   
   if (!token) {
     return <Navigate to="/login" replace />;


### PR DESCRIPTION
- PrivateRoute에서 localStorage 토큰 키를 'token'에서 'access_token'으로 변경
- authService.login()에서 저장하는 키와 PrivateRoute에서 체크하는 키 일치
- 로그인 성공 후 /dashboard로 정상 리다이렉션 가능

문제:
- authService: localStorage.setItem('access_token', token)
- PrivateRoute: localStorage.getItem('token')
- 키 불일치로 인증 실패 무한루프 발생

해결:
- PrivateRoute에서 'access_token' 키로 통일

🤖 Generated with [Claude Code](https://claude.ai/code)